### PR TITLE
enh: update upload-pages-artifact to v1.0.9

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -34,8 +34,8 @@ jobs:
         with:
           source: ./
           destination: ./_site
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1.0.8
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v1.0.9
 
   # Deployment job
   deploy:


### PR DESCRIPTION
      - name: Upload GitHub Pages artifact
        uses: actions/upload-pages-artifact@v1.0.9