### PR TITLE
[info](build): more debug info

### DIFF
--- a/.github/workflows/pandoc.yml
+++ b/.github/workflows/pandoc.yml
@@ -39,6 +39,7 @@ jobs:
           echo $f # debug
           FILE_NAME=$(basename "$f" | sed 's/.md//g')
           echo $FILE_NAME # debug
+          echo output/${FILE_NAME}.pdf # debug 
           # pandoc --standalone \ # --template styles/chmduquesne.tex \
           #   --from markdown --to context \
           #  --variable papersize=letter \


### PR DESCRIPTION
At least I get a different error message.

```
for f in markdown/*.md; do
    echo $f # debug
    FILE_NAME=$(basename "$f" | sed 's/.md//g')
    echo $FILE_NAME # debug
    # pandoc --standalone \ # --template styles/chmduquesne.tex \
    #   --from markdown --to context \
    #  --variable papersize=letter \
    #   --verbose \ # debug
    #   --output output/${FILE_NAME}.tex $f
    # mtxrun --path=output --result=${FILE_NAME}.pdf --script context ${FILE_NAME}.tex
    pandoc --standalone --from markdown --to pdf --output output/${FILE_NAME}.pdf $f
    git add ${FILE_NAME}.pdf
  done
  shell: /usr/bin/bash -e {0}
markdown/Accounts.md
Accounts
fatal: pathspec 'Accounts.pdf' did not match any files
Error: Process completed with exit code 12[8](https://github.com/RalphHightower/EOL-RalphHightower/actions/runs/12673869770/job/35321205288#step:6:8).
```